### PR TITLE
fix: contextmenu doesn't work on windows

### DIFF
--- a/script/background.js
+++ b/script/background.js
@@ -5,7 +5,12 @@ chrome.contextMenus.create({
   onclick: function (link) {
     chrome.storage.sync.get(["telemark_code"], function (result) {
       if (result.telemark_code) {
-        sendToTelegram(link.linkUrl, getBrowser() == "Chrome" ? link.selectionText : link.linkText, result.telemark_code);
+        var text;
+        if (typeof link.linkText !== "undefined") text = link.linkText;
+        else if (typeof link.selectionText !== "undefined")
+          text = link.selectionText;
+        else text = link.linkUrl;
+        sendToTelegram(link.linkUrl, text, result.telemark_code);
       } else {
         alert("First enter your telemark code.");
       }


### PR DESCRIPTION
On macOS, when you right click a link, its text will be selected as well and therefore it's accessible through `link.selectionText`, but unfortunately it's not the case on windows. so when the extension tries to send a request to the API, it's text will be null and therefore nothing will be sent. Although `link.linkText` is available on firefox, so first check for it and if it didn't exist, then check for `link.selectionText` and if it didn't exist either, use the link url itself.

Fixes: #28